### PR TITLE
System operations

### DIFF
--- a/mdtool/src/ConfigManager.cpp
+++ b/mdtool/src/ConfigManager.cpp
@@ -1,12 +1,8 @@
 #include "ConfigManager.hpp"
 
-#include <iostream>
 #include <filesystem>
-#ifdef _WIN32
-#include <windows.h>
-#else
+#include <iostream>
 #include <unistd.h>
-#endif
 
 #include "dirent.h"
 
@@ -281,21 +277,7 @@ void ConfigManager::computeFullPathAndName(std::string userPath)
 	if ((userPath.rfind("./", 0) == 0) || (userPath.rfind("/", 0) == 0))
 	{
 		if ((userPath.rfind("./", 0) == 0))
-		{
-			char buffer[PATH_MAX];
-#ifdef _WIN32
-			if (GetCurrentDirectory(PATH_MAX, buffer))
-				return (buffer + userFilePath.substr(1));
-			else
-				throw std::runtime_error("GetCurrentDirectory() error: " +
-										 std::to_string(GetLastError()));
-#else
-			if (getcwd(buffer, sizeof(buffer)) != NULL)
-				userConfigPath = (buffer + userPath.substr(1));
-			else
-				perror("getcwd() error");
-#endif
-		}
+			userConfigPath = std::filesystem::absolute(userPath.substr(2));
 		else
 			userConfigPath = userPath;
 	}

--- a/mdtool/src/mdtool.cpp
+++ b/mdtool/src/mdtool.cpp
@@ -1,9 +1,8 @@
 #include "mdtool.hpp"
 
-#include <unistd.h>
-
 #include <filesystem>
 #include <numeric>
+#include <unistd.h>
 
 #include "ConfigManager.hpp"
 #include "ui.hpp"
@@ -600,17 +599,7 @@ void MDtool::setupReadConfig(u16 id, const std::string& cfgName)
 	/* Saving motor config to file */
 	if (saveConfig)
 	{
-		std::string saveConfigPath;
-		char		buffer[PATH_MAX];
-
-		if (getcwd(buffer, sizeof(buffer)) != NULL)
-		{
-			saveConfigPath = std::string(buffer) + "/" + configName;
-		}
-		else
-		{
-			perror("getcwd() error");
-		}
+		std::string saveConfigPath = std::filesystem::absolute(configName);
 
 		bool checkFile = true;
 		while (checkFile)


### PR DESCRIPTION
Use `filesystem` library for file and directory operations and computing absolute paths.