### PR TITLE
Cs 40 make md register iterable

### DIFF
--- a/candlelib/src/MD/MD.hpp
+++ b/candlelib/src/MD/MD.hpp
@@ -234,7 +234,7 @@ namespace mab
         /// overwritten by received data)
         /// @return
         template <class T>
-        inline std::pair<RegisterEntry_S<T>, Error_t> readRegister(RegisterEntry_S<T>& reg)
+        inline std::pair<MDRegisterEntry_S<T>, Error_t> readRegister(MDRegisterEntry_S<T>& reg)
         {
             auto regTuple   = std::make_tuple(std::reference_wrapper(reg));
             auto resultPair = readRegisters(regTuple);
@@ -248,10 +248,10 @@ namespace mab
         /// read)
         /// @return Register values read and error type on failure
         template <class... T>
-        inline std::pair<std::tuple<RegisterEntry_S<T>...>, Error_t> readRegisters(
-            RegisterEntry_S<T>&... regs)
+        inline std::pair<std::tuple<MDRegisterEntry_S<T>...>, Error_t> readRegisters(
+            MDRegisterEntry_S<T>&... regs)
         {
-            auto regTuple   = std::tuple<RegisterEntry_S<T>&...>(regs...);
+            auto regTuple   = std::tuple<MDRegisterEntry_S<T>&...>(regs...);
             auto resultPair = readRegisters(regTuple);
             return resultPair;
         }
@@ -261,8 +261,8 @@ namespace mab
         /// @param regs Tuple with register references intended to be read (overwritten by read)
         /// @return Register values read and error type on failure
         template <class... T>
-        inline std::pair<std::tuple<RegisterEntry_S<T>...>, Error_t> readRegisters(
-            std::tuple<RegisterEntry_S<T>&...>& regs)
+        inline std::pair<std::tuple<MDRegisterEntry_S<T>...>, Error_t> readRegisters(
+            std::tuple<MDRegisterEntry_S<T>&...>& regs)
         {
             m_log.debug("Reading register...");
 
@@ -307,9 +307,9 @@ namespace mab
         /// @param ...regs Registry references to be written to memory
         /// @return Error on failure
         template <class... T>
-        inline Error_t writeRegisters(RegisterEntry_S<T>&... regs)
+        inline Error_t writeRegisters(MDRegisterEntry_S<T>&... regs)
         {
-            auto tuple = std::tuple<RegisterEntry_S<T>&...>(regs...);
+            auto tuple = std::tuple<MDRegisterEntry_S<T>&...>(regs...);
             return writeRegisters(tuple);
         }
 
@@ -318,7 +318,7 @@ namespace mab
         /// @param regs Tuple of register reference to be written
         /// @return Error on failure
         template <class... T>
-        inline Error_t writeRegisters(std::tuple<RegisterEntry_S<T>&...>& regs)
+        inline Error_t writeRegisters(std::tuple<MDRegisterEntry_S<T>&...>& regs)
         {
             m_log.debug("Writing register...");
             std::vector<u8> frame;
@@ -359,7 +359,8 @@ namespace mab
         }
 
         template <class... T>
-        static inline std::vector<u8> serializeMDRegisters(std::tuple<RegisterEntry_S<T>&...>& regs)
+        static inline std::vector<u8> serializeMDRegisters(
+            std::tuple<MDRegisterEntry_S<T>&...>& regs)
         {
             std::vector<u8> serialized;
             std::apply(
@@ -375,8 +376,8 @@ namespace mab
         }
 
         template <class... T>
-        static inline bool deserializeMDRegisters(std::vector<u8>&                    output,
-                                                  std::tuple<RegisterEntry_S<T>&...>& regs)
+        static inline bool deserializeMDRegisters(std::vector<u8>&                      output,
+                                                  std::tuple<MDRegisterEntry_S<T>&...>& regs)
         {
             bool failure            = false;
             auto performForEachElem = [&](auto& reg)  // Capture by reference to modify 'failure'

--- a/commons/shared_data/md_types.hpp
+++ b/commons/shared_data/md_types.hpp
@@ -161,7 +161,7 @@ namespace mab
     };
 
     template <typename T>
-    struct RegisterEntry_S
+    struct MDRegisterEntry_S
     {
       public:
         T value;
@@ -173,25 +173,25 @@ namespace mab
         std::array<u8, sizeof(value) + sizeof(m_regAddress)> serializedBuffer;
 
       public:
-        RegisterEntry_S(RegisterAccessLevel_E accessLevel, u16 regAddress)
+        MDRegisterEntry_S(RegisterAccessLevel_E accessLevel, u16 regAddress)
             : m_accessLevel(accessLevel), m_regAddress(regAddress)
         {
         }
 
-        RegisterEntry_S(const RegisterEntry_S& otherReg)
+        MDRegisterEntry_S(const MDRegisterEntry_S& otherReg)
             : m_accessLevel(otherReg.m_accessLevel), m_regAddress(otherReg.m_regAddress)
         {
             value = otherReg.value;
         }
 
-        RegisterEntry_S& operator=(T otherValue)
+        MDRegisterEntry_S& operator=(T otherValue)
         {
             value = otherValue;
 
             return *this;
         }
 
-        T operator=(RegisterEntry_S& reg)
+        T operator=(MDRegisterEntry_S& reg)
         {
             return reg.value;
         }
@@ -230,7 +230,7 @@ namespace mab
         }
     };
     template <typename T, size_t N>
-    struct RegisterEntry_S<T[N]>
+    struct MDRegisterEntry_S<T[N]>
     {
         T value[N];
 
@@ -241,11 +241,11 @@ namespace mab
         std::array<u8, sizeof(value) + sizeof(m_regAddress)> serializedBuffer;
 
       public:
-        RegisterEntry_S(RegisterAccessLevel_E accessLevel, u16 regAddress)
+        MDRegisterEntry_S(RegisterAccessLevel_E accessLevel, u16 regAddress)
             : m_accessLevel(accessLevel), m_regAddress(regAddress)
         {
         }
-        RegisterEntry_S(const RegisterEntry_S& otherReg)
+        MDRegisterEntry_S(const MDRegisterEntry_S& otherReg)
             : m_accessLevel(otherReg.m_accessLevel), m_regAddress(otherReg.m_regAddress)
         {
             static_assert(std::is_same_v<decltype(otherReg.value), decltype(value)>);
@@ -253,14 +253,14 @@ namespace mab
         }
 
         // This is kinda unsafe due to c-array not passing size, use with caution
-        RegisterEntry_S& operator=(T* otherValue)
+        MDRegisterEntry_S& operator=(T* otherValue)
         {
             memcpy(value, otherValue, N);
 
             return *this;
         }
 
-        T* operator=(RegisterEntry_S& reg)
+        T* operator=(MDRegisterEntry_S& reg)
         {
             return value;
         }
@@ -304,7 +304,7 @@ namespace mab
         RegisterAccessLevel_E const RW = RegisterAccessLevel_E::RW;
         RegisterAccessLevel_E const WO = RegisterAccessLevel_E::WO;
         template <class T>
-        using regE_S = RegisterEntry_S<T>;
+        using regE_S = MDRegisterEntry_S<T>;
 
 #define MD_REG(name, type, addr, access) regE_S<type> name = regE_S<type>(access, addr);
         REGISTER_LIST


### PR DESCRIPTION
Moved definitions of registers to macro and added:
- RegisterAddress_E - enum that will always contain all of the MD registers addresses
- getAllRegisters() - to tie MDRegisters_t struct into l-reference tuple to be iterated through
- forEachRegister(MDRegisters_S& regs, F&& func) - helper method to perform actions on all of the registers (can be used for finding and editing particular address and so on) 