### PR TITLE
CS-49 MD register return

### DIFF
--- a/candlelib/src/MD/MD.cpp
+++ b/candlelib/src/MD/MD.cpp
@@ -9,7 +9,7 @@ namespace mab
         //  m_mdRegisters.hardwareType.value.deviceType = deviceType_E::UNKNOWN_DEVICE;
         //  auto mfDataResult                           = readRegister(m_mdRegisters.hardwareType);
 
-        // if (mfDataResult.second == Error_t::OK)
+        // if (mfDataresult == Error_t::OK)
         // {
         //     m_mdRegisters.hardwareType = mfDataResult.first;
 
@@ -22,7 +22,7 @@ namespace mab
 
         auto mfLegacydataResult = readRegister(m_mdRegisters.legacyHardwareVersion);
 
-        if (mfLegacydataResult.second != Error_t::OK)
+        if (mfLegacydataResult != Error_t::OK)
             return Error_t::NOT_CONNECTED;
 
         if (m_mdRegisters.legacyHardwareVersion.value != 0)
@@ -54,7 +54,7 @@ namespace mab
         }
         m_log.info("Driver enabled");
         m_mdRegisters.motionModeStatus = 0;
-        if (readRegisters(m_mdRegisters.motionModeStatus).second != MD::Error_t::OK)
+        if (readRegisters(m_mdRegisters.motionModeStatus) != MD::Error_t::OK)
         {
             m_log.error("Motion status check failed");
             return MD::Error_t::TRANSFER_FAILED;
@@ -322,13 +322,13 @@ namespace mab
     MD::getQuickStatus()
     {
         auto result = readRegister(m_mdRegisters.quickStatus);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read quick status vector!");
-            return std::make_pair(m_status.quickStatus, result.second);
+            return std::make_pair(m_status.quickStatus, result);
         }
         MDStatus::toMap(m_mdRegisters.quickStatus.value, m_status.quickStatus);
-        return std::make_pair(m_status.quickStatus, result.second);
+        return std::make_pair(m_status.quickStatus, result);
     }
 
     std::pair<const std::unordered_map<const MDStatus::EncoderStatusBits, MDStatus::StatusItem_S>,
@@ -336,13 +336,13 @@ namespace mab
     MD::getMainEncoderStatus()
     {
         auto result = readRegister(m_mdRegisters.mainEncoderStatus);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read main encoder errors!");
-            return std::make_pair(m_status.encoderStatus, result.second);
+            return std::make_pair(m_status.encoderStatus, result);
         }
         MDStatus::toMap(m_mdRegisters.mainEncoderStatus.value, m_status.encoderStatus);
-        return std::make_pair(m_status.encoderStatus, result.second);
+        return std::make_pair(m_status.encoderStatus, result);
     }
 
     std::pair<const std::unordered_map<const MDStatus::EncoderStatusBits, MDStatus::StatusItem_S>,
@@ -350,13 +350,13 @@ namespace mab
     MD::getOutputEncoderStatus()
     {
         auto result = readRegister(m_mdRegisters.auxEncoderStatus);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read output encoder errors!");
-            return std::make_pair(m_status.encoderStatus, result.second);
+            return std::make_pair(m_status.encoderStatus, result);
         }
         MDStatus::toMap(m_mdRegisters.auxEncoderStatus.value, m_status.encoderStatus);
-        return std::make_pair(m_status.encoderStatus, result.second);
+        return std::make_pair(m_status.encoderStatus, result);
     }
 
     std::pair<
@@ -365,13 +365,13 @@ namespace mab
     MD::getCalibrationStatus()
     {
         auto result = readRegister(m_mdRegisters.calibrationStatus);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(m_status.calibrationStatus, result.second);
+            return std::make_pair(m_status.calibrationStatus, result);
         }
         MDStatus::toMap(m_mdRegisters.calibrationStatus.value, m_status.calibrationStatus);
-        return std::make_pair(m_status.calibrationStatus, result.second);
+        return std::make_pair(m_status.calibrationStatus, result);
     }
 
     std::pair<const std::unordered_map<const MDStatus::BridgeStatusBits, MDStatus::StatusItem_S>,
@@ -379,13 +379,13 @@ namespace mab
     MD::getBridgeStatus()
     {
         auto result = readRegister(m_mdRegisters.bridgeStatus);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(m_status.bridgeStatus, result.second);
+            return std::make_pair(m_status.bridgeStatus, result);
         }
         MDStatus::toMap(m_mdRegisters.bridgeStatus.value, m_status.bridgeStatus);
-        return std::make_pair(m_status.bridgeStatus, result.second);
+        return std::make_pair(m_status.bridgeStatus, result);
     }
 
     std::pair<const std::unordered_map<const MDStatus::HardwareStatusBits, MDStatus::StatusItem_S>,
@@ -393,13 +393,13 @@ namespace mab
     MD::getHardwareStatus()
     {
         auto result = readRegister(m_mdRegisters.hardwareStatus);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(m_status.hardwareStatus, result.second);
+            return std::make_pair(m_status.hardwareStatus, result);
         }
         MDStatus::toMap(m_mdRegisters.hardwareStatus.value, m_status.hardwareStatus);
-        return std::make_pair(m_status.hardwareStatus, result.second);
+        return std::make_pair(m_status.hardwareStatus, result);
     }
 
     std::pair<
@@ -408,13 +408,13 @@ namespace mab
     MD::getCommunicationStatus()
     {
         auto result = readRegister(m_mdRegisters.communicationStatus);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(m_status.communicationStatus, result.second);
+            return std::make_pair(m_status.communicationStatus, result);
         }
         MDStatus::toMap(m_mdRegisters.communicationStatus.value, m_status.communicationStatus);
-        return std::make_pair(m_status.communicationStatus, result.second);
+        return std::make_pair(m_status.communicationStatus, result);
     }
 
     std::pair<const std::unordered_map<const MDStatus::MotionStatusBits, MDStatus::StatusItem_S>,
@@ -422,79 +422,79 @@ namespace mab
     MD::getMotionStatus()
     {
         auto result = readRegister(m_mdRegisters.motionStatus);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(m_status.motionStatus, result.second);
+            return std::make_pair(m_status.motionStatus, result);
         }
         MDStatus::toMap(m_mdRegisters.motionStatus.value, m_status.motionStatus);
-        return std::make_pair(m_status.motionStatus, result.second);
+        return std::make_pair(m_status.motionStatus, result);
     }
 
     std::pair<float, MD::Error_t> MD::getPosition()
     {
         auto result = readRegister(m_mdRegisters.mainEncoderPosition);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(0, result.second);
+            return std::make_pair(0, result);
         }
-        return std::make_pair(m_mdRegisters.mainEncoderPosition.value, result.second);
+        return std::make_pair(m_mdRegisters.mainEncoderPosition.value, result);
     }
 
     std::pair<float, MD::Error_t> MD::getVelocity()
     {
         auto result = readRegister(m_mdRegisters.mainEncoderVelocity);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(0, result.second);
+            return std::make_pair(0, result);
         }
-        return std::make_pair(m_mdRegisters.mainEncoderVelocity.value, result.second);
+        return std::make_pair(m_mdRegisters.mainEncoderVelocity.value, result);
     }
 
     std::pair<float, MD::Error_t> MD::getTorque()
     {
         auto result = readRegister(m_mdRegisters.motorTorque);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(0, result.second);
+            return std::make_pair(0, result);
         }
-        return std::make_pair(m_mdRegisters.motorTorque.value, result.second);
+        return std::make_pair(m_mdRegisters.motorTorque.value, result);
     }
 
     std::pair<float, MD::Error_t> MD::getOutputEncoderPosition()
     {
         auto result = readRegister(m_mdRegisters.auxEncoderPosition);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(0, result.second);
+            return std::make_pair(0, result);
         }
-        return std::make_pair(m_mdRegisters.auxEncoderPosition.value, result.second);
+        return std::make_pair(m_mdRegisters.auxEncoderPosition.value, result);
     }
 
     std::pair<float, MD::Error_t> MD::getOutputEncoderVelocity()
     {
         auto result = readRegister(m_mdRegisters.auxEncoderVelocity);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(0, result.second);
+            return std::make_pair(0, result);
         }
-        return std::make_pair(m_mdRegisters.auxEncoderVelocity.value, result.second);
+        return std::make_pair(m_mdRegisters.auxEncoderVelocity.value, result);
     }
 
     std::pair<u8, MD::Error_t> MD::getTemperature()
     {
         auto result = readRegister(m_mdRegisters.motorTemperature);
-        if (result.second != Error_t::OK)
+        if (result != Error_t::OK)
         {
             m_log.error("Could not read ");
-            return std::make_pair(0, result.second);
+            return std::make_pair(0, result);
         }
-        return std::make_pair(m_mdRegisters.motorTemperature.value, result.second);
+        return std::make_pair(m_mdRegisters.motorTemperature.value, result);
     }
 
     /// @brief This test should be performed with 1M datarate on CAN network

--- a/candlelib/src/MD/MD.hpp
+++ b/candlelib/src/MD/MD.hpp
@@ -247,14 +247,14 @@ namespace mab
         /// @tparam T Register entry underlying type (should be deducible)
         /// @param reg Register entry reference to be read from memory (reference is
         /// overwritten by received data)
-        /// @return Pair containing the register with data and error type on failure
+        /// @return Error type on failure
         template <class T>
-        inline std::pair<MDRegisterEntry_S<T>, Error_t> readRegister(MDRegisterEntry_S<T>& reg)
+        inline Error_t readRegister(MDRegisterEntry_S<T>& reg)
         {
-            auto regTuple   = std::make_tuple(std::reference_wrapper(reg));
-            auto resultPair = readRegisters(regTuple);
-            reg             = std::get<0>(regTuple);
-            return std::pair(reg, resultPair.second);
+            auto regTuple = std::make_tuple(std::reference_wrapper(reg));
+            auto result   = readRegisters(regTuple);
+            reg           = std::get<0>(regTuple);
+            return result;
         }
 
         /// @brief Write register to the memory of the MD
@@ -281,10 +281,9 @@ namespace mab
         /// @tparam ...T Register underlying types
         /// @param ...regs References to the registers to be read from the MD memory (overwritten by
         /// read)
-        /// @return Register values read and error type on failure
+        /// @return Error type on failure
         template <class... T>
-        inline std::pair<std::tuple<MDRegisterEntry_S<T>...>, Error_t> readRegisters(
-            MDRegisterEntry_S<T>&... regs)
+        inline Error_t readRegisters(MDRegisterEntry_S<T>&... regs)
         {
             auto regTuple   = std::tuple<MDRegisterEntry_S<T>&...>(regs...);
             auto resultPair = readRegisters(regTuple);
@@ -294,10 +293,9 @@ namespace mab
         /// @brief Read registers from the memory of the MD
         /// @tparam ...T Register entry underlying type (should be deducible)
         /// @param regs Tuple with register references intended to be read (overwritten by read)
-        /// @return Register values read and error type on failure
+        /// @return Error type on failure
         template <class... T>
-        inline std::pair<std::tuple<MDRegisterEntry_S<T>...>, Error_t> readRegisters(
-            std::tuple<MDRegisterEntry_S<T>&...>& regs)
+        inline Error_t readRegisters(std::tuple<MDRegisterEntry_S<T>&...>& regs)
         {
             m_log.debug("Reading register...");
 
@@ -321,7 +319,7 @@ namespace mab
             {
                 std::string errMsg = "Attempt to read write-only registers: " + writeOnlyRegNames;
                 m_log.error(errMsg.c_str());
-                return std::pair(regs, Error_t::REQUEST_INVALID);
+                return Error_t::REQUEST_INVALID;
             }
 
             // clear all the values for the incoming data from the MD
@@ -353,10 +351,10 @@ namespace mab
             if (deserializeFailed)
             {
                 m_log.error("Error while parsing response!");
-                return std::pair(regs, Error_t::TRANSFER_FAILED);
+                return Error_t::TRANSFER_FAILED;
             }
 
-            return std::pair(regs, Error_t::OK);
+            return Error_t::OK;
         }
 
         /// @brief Write registers to MD memory

--- a/candlelib/src/MD/MD_test.cpp
+++ b/candlelib/src/MD/MD_test.cpp
@@ -53,7 +53,7 @@ TEST_F(MD_test, checkROAccess)
     mab::MD md(100, m_candle);
 
     auto resultRead = md.readRegister(registers.auxEncoderPosition);
-    EXPECT_EQ(resultRead.second, mab::MD::Error_t::OK);
+    EXPECT_EQ(resultRead, mab::MD::Error_t::OK);
 
     auto resultWrite = md.writeRegister(registers.auxEncoderPosition);
     EXPECT_EQ(resultWrite, mab::MD::Error_t::REQUEST_INVALID);
@@ -76,5 +76,5 @@ TEST_F(MD_test, checkWOAccess)
     EXPECT_EQ(resultWrite, mab::MD::Error_t::OK);
 
     auto resultRead = md.readRegister(registers.runBlink);
-    EXPECT_EQ(resultRead.second, mab::MD::Error_t::REQUEST_INVALID);
+    EXPECT_EQ(resultRead, mab::MD::Error_t::REQUEST_INVALID);
 }

--- a/candletool/src/candletool.cpp
+++ b/candletool/src/candletool.cpp
@@ -323,7 +323,7 @@ void CandleTool::setupCalibrationOutput(u16 id)
         log.error("No output encoder is configured!");
         return;
     }
-    if (resultRead.second != MD::Error_t::OK)
+    if (resultRead != MD::Error_t::OK)
     {
         log.error("Failed to read output encoder type for the driver with id %d!", id);
     }
@@ -767,8 +767,8 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
 
     if (cfgName == "")
     {
-        if (md.readRegisters(regs.motorName).second != MD::Error_t::OK)
-            if (md.readRegisters(regs.motorName).second != MD::Error_t::OK)
+        if (md.readRegisters(regs.motorName) != MD::Error_t::OK)
+            if (md.readRegisters(regs.motorName) != MD::Error_t::OK)
             {
                 log.error("Failed to read motor config %d!", id);
                 snprintf(motorNameChar, 24, "UNKNOWN_MD");
@@ -788,16 +788,14 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
                          regs.motorIMax,
                          regs.motorGearRatio,
                          regs.motorTorqueBandwidth,
-                         regs.motorKV)
-            .second != MD::Error_t::OK)
+                         regs.motorKV) != MD::Error_t::OK)
     {
         if (md.readRegisters(regs.motorPolePairs,
                              regs.motorKt,
                              regs.motorIMax,
                              regs.motorGearRatio,
                              regs.motorTorqueBandwidth,
-                             regs.motorKV)
-                .second != MD::Error_t::OK)
+                             regs.motorKV) != MD::Error_t::OK)
         {
             log.warn("Failed to read motor config!");
         }
@@ -818,9 +816,9 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
     readIni["motor"]["max current"]      = prettyFloatToString(regs.motorIMax.value);
     readIni["motor"]["torque bandwidth"] = prettyFloatToString(regs.motorTorqueBandwidth.value);
 
-    if (md.readRegisters(regs.motorShutdownTemp).second != MD::Error_t::OK)
+    if (md.readRegisters(regs.motorShutdownTemp) != MD::Error_t::OK)
     {
-        if (md.readRegisters(regs.motorShutdownTemp).second != MD::Error_t::OK)
+        if (md.readRegisters(regs.motorShutdownTemp) != MD::Error_t::OK)
         {
             log.warn("Failed to read motor config!");
         }
@@ -835,16 +833,14 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
                          regs.maxAcceleration,
                          regs.maxDeceleration,
                          regs.positionLimitMax,
-                         regs.positionLimitMin)
-            .second != MD::Error_t::OK)
+                         regs.positionLimitMin) != MD::Error_t::OK)
     {
         if (md.readRegisters(regs.maxTorque,
                              regs.maxVelocity,
                              regs.maxAcceleration,
                              regs.maxDeceleration,
                              regs.positionLimitMax,
-                             regs.positionLimitMin)
-                .second != MD::Error_t::OK)
+                             regs.positionLimitMin) != MD::Error_t::OK)
         {
             log.warn("Failed to read motor config!");
         }
@@ -863,12 +859,13 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
     readIni["limits"]["max torque"]       = prettyFloatToString(regs.maxTorque.value);
 
     /* Motor config - profile section */
-    if (md.readRegisters(regs.profileVelocity, regs.profileAcceleration, regs.profileDeceleration)
-            .second != MD::Error_t::OK)
+    if (md.readRegisters(regs.profileVelocity,
+                         regs.profileAcceleration,
+                         regs.profileDeceleration) != MD::Error_t::OK)
     {
-        if (md.readRegisters(
-                  regs.profileVelocity, regs.profileAcceleration, regs.profileDeceleration)
-                .second != MD::Error_t::OK)
+        if (md.readRegisters(regs.profileVelocity,
+                             regs.profileAcceleration,
+                             regs.profileDeceleration) != MD::Error_t::OK)
         {
             log.warn("Failed to read motor config!");
         }
@@ -885,9 +882,9 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
 
     /* Motor config - output encoder section */
 
-    if (md.readRegisters(regs.auxEncoder, regs.auxEncoderMode).second != MD::Error_t::OK)
+    if (md.readRegisters(regs.auxEncoder, regs.auxEncoderMode) != MD::Error_t::OK)
     {
-        if (md.readRegisters(regs.auxEncoder, regs.auxEncoderMode).second != MD::Error_t::OK)
+        if (md.readRegisters(regs.auxEncoder, regs.auxEncoderMode) != MD::Error_t::OK)
         {
             log.warn("Failed to read motor config!");
         }
@@ -906,8 +903,8 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
 
     /* Motor config - position PID section */
     if (md.readRegisters(
-              regs.motorPosPidKp, regs.motorPosPidKi, regs.motorPosPidKd, regs.motorPosPidWindup)
-            .second != MD::Error_t::OK)
+            regs.motorPosPidKp, regs.motorPosPidKi, regs.motorPosPidKd, regs.motorPosPidWindup) !=
+        MD::Error_t::OK)
 
     {
         log.warn("Failed to read motor config!");
@@ -919,8 +916,8 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
 
     /* Motor config - velocity PID section */
     if (md.readRegisters(
-              regs.motorVelPidKp, regs.motorVelPidKi, regs.motorVelPidKd, regs.motorVelPidWindup)
-            .second != MD::Error_t::OK)
+            regs.motorVelPidKp, regs.motorVelPidKi, regs.motorVelPidKd, regs.motorVelPidWindup) !=
+        MD::Error_t::OK)
     {
         log.warn("Failed to read motor config!");
     }
@@ -930,7 +927,7 @@ void CandleTool::setupReadConfig(u16 id, const std::string& cfgName)
     readIni["velocity PID"]["windup"] = prettyFloatToString(regs.motorVelPidWindup.value);
 
     /* Motor config - impedance PD section */
-    if (md.readRegisters(regs.motorImpPidKp, regs.motorImpPidKd).second != MD::Error_t::OK)
+    if (md.readRegisters(regs.motorImpPidKp, regs.motorImpPidKd) != MD::Error_t::OK)
     {
         log.warn("Failed to read motor config!");
     }
@@ -998,7 +995,7 @@ void CandleTool::setupInfo(u16 id, bool printAll)
                 return;
             if (reg.m_accessLevel != RegisterAccessLevel_E::WO)
             {
-                auto fault = md.readRegisters(reg).second;
+                auto fault = md.readRegisters(reg);
                 if (fault != MD::Error_t::OK)
                     log.error("Error while reading register %s", reg.m_name.data());
             }
@@ -1016,7 +1013,7 @@ void CandleTool::setupInfo(u16 id, bool printAll)
             return;
         if (reg.m_accessLevel != RegisterAccessLevel_E::WO)
         {
-            auto fault = md.readRegisters(reg).second;
+            auto fault = md.readRegisters(reg);
             if (fault != MD::Error_t::OK)
                 log.error("Error while reading register %s", reg.m_name.data());
         }
@@ -1278,7 +1275,7 @@ void CandleTool::registerRead(u16 id, u16 regAdress)
             if constexpr (std::is_arithmetic_v<T>)
             {
                 auto result = md.readRegister(reg);
-                if (result.second != MD::Error_t::OK)
+                if (result != MD::Error_t::OK)
                 {
                     log.error("Failed to read register %d", regAdress);
                     return false;
@@ -1290,7 +1287,7 @@ void CandleTool::registerRead(u16 id, u16 regAdress)
             else if constexpr (std::is_same<std::decay_t<T>, char*>::value)
             {
                 auto result = md.readRegisters(reg);
-                if (result.second != MD::Error_t::OK)
+                if (result != MD::Error_t::OK)
                 {
                     log.error("Failed to read register %d", regAdress);
                     return false;


### PR DESCRIPTION
So far MD register read method was returning both error and the register while editing register reference. Now it just edits the reference and returns error on failure.