### PR TITLE
feat: added WRITE_REGISTER_DEFAULT_RESONSE and WRITE_REGISTER MdFrameIds

### DIFF
--- a/candlelib/src/MD/MD.hpp
+++ b/candlelib/src/MD/MD.hpp
@@ -322,7 +322,7 @@ namespace mab
 
             // Add protocol read header [0x41, 0x00]
             std::vector<u8> frame;
-            frame.push_back((u8)MdFrameId_E::FRAME_READ_REGISTER);
+            frame.push_back((u8)MdFrameId_E::READ_REGISTER);
             frame.push_back((u8)0x0);
             // Add serialized register data to be read [LSB addr, MSB addr, payload-bytes...]
             auto payload = serializeMDRegisters(regs);
@@ -406,16 +406,15 @@ namespace mab
             }
 
             std::vector<u8> frame;
-            frame.push_back((u8)MdFrameId_E::FRAME_WRITE_REGISTER);
+            frame.push_back((u8)MdFrameId_E::WRITE_REGISTER);
             frame.push_back((u8)0x0);
             auto payload = serializeMDRegisters(regs);
             frame.insert(frame.end(), payload.begin(), payload.end());
             auto readRegResult = transferCanFrame(frame, DEFAULT_RESPONSE_SIZE);
 
-            if (readRegResult.first.at(0) == 0xA0)
-            {
-                return Error_t::OK;
-            }
+            MdFrameId_E frameId = (MdFrameId_E)readRegResult.first.at(0);
+            if (frameId == MdFrameId_E::RESPONSE_DEFAULT || frameId == MdFrameId_E::WRITE_REGISTER)
+                return Error_t::OK; // TODO: Possible do smth with received data?
             else
             {
                 m_log.error("Error in the register write response!");

--- a/commons/shared_data/md_types.hpp
+++ b/commons/shared_data/md_types.hpp
@@ -148,9 +148,10 @@ namespace mab
 {
     enum class MdFrameId_E : u8
     {
-        FRAME_WRITE_REGISTER = 0x40,
-        FRAME_READ_REGISTER  = 0x41,
-        RESPONSE_DEFAULT     = 0xA0
+        WRITE_REGISTER_DEFAULT_RESPONSE = 0x40,
+        READ_REGISTER                   = 0x41,
+        WRITE_REGISTER                  = 0x42,
+        RESPONSE_DEFAULT                = 0xA0
     };
 
     enum class RegisterAccessLevel_E : u8


### PR DESCRIPTION
Features:
- WRITE_REGISTER renamed to WRITE_REGISTER_DEFAULT_RESPONSE (0x40)
- new frame type added WRITE_REGISTER that will produce response similar to READ_REAGISTER

Comment:
- using new WRITE_REGISTER frame with <= 8 bytes of data, forces response of the same length, which makes the system compatibile with CAN 2.0