### PR TITLE
Cs 212 integrate driver bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,7 @@ wheelhouse
 
 # Executables
 *.exe
+# With exception for a driver
+!candlesdk-win-driver.exe 
 *.out
 *.app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,51 +7,50 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CANDLESDK_VERSION_1 1)
 set(CANDLESDK_VERSION_2 1)
 set(CANDLESDK_VERSION_3 0)
-set(CANDLESDK_VERSION ${CANDLESDK_VERSION_1}.${CANDLESDK_VERSION_2}.${CANDLESDK_VERSION_3})
+set(CANDLESDK_VERSION
+    ${CANDLESDK_VERSION_1}.${CANDLESDK_VERSION_2}.${CANDLESDK_VERSION_3})
 add_compile_definitions(CANDLESDK_VERSION="${CANDLESDK_VERSION}")
 get_tag(CANDLESDK_VERSION_TAG)
 
-project(candlesdk VERSION ${CANDLESDK_VERSION_1}.${CANDLESDK_VERSION_2}.${CANDLESDK_VERSION_3})
+project(
+  candlesdk
+  VERSION ${CANDLESDK_VERSION_1}.${CANDLESDK_VERSION_2}.${CANDLESDK_VERSION_3})
 
 message("CandleSDK version: ${CANDLESDK_VERSION} ${CANDLESDK_VERSION_TAG}")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-add_compile_options(
-  -Wfatal-errors
-  -Wall
-  -Wextra
-  -Wpedantic
-  -Wno-unused-parameter
-  -Wno-missing-field-initializers)
+add_compile_options(-Wfatal-errors -Wall -Wextra -Wpedantic
+                    -Wno-unused-parameter -Wno-missing-field-initializers)
 
 if(NOT WIN32)
-    add_compile_options(
-  -Werror)
+  add_compile_options(-Werror)
+  add_compile_definitions(WIN32_MEAN_AND_LEAN) # This define is needed for
+  # windows.h to exclude some less used APIs
 endif()
 
 set(mINI_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/third_party/mINI/inc/)
 if(NOT DEFINED CANDLE_BUILD_STATIC)
-    set(CANDLE_BUILD_STATIC TRUE)
+  set(CANDLE_BUILD_STATIC TRUE)
 endif()
 
 macro(add_unit_test_executable test_name)
-    message("Adding unit test executable ${test_name}")
-    add_executable(${test_name} ${ARGN})
-    target_link_libraries(${test_name} PRIVATE Unit_test)
-    set_target_properties(${test_name} PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/ut_runners/
-        OUTPUT_NAME test_${test_name}
-    )
+  message("Adding unit test executable ${test_name}")
+  add_executable(${test_name} ${ARGN})
+  target_link_libraries(${test_name} PRIVATE Unit_test)
+  set_target_properties(
+    ${test_name}
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/ut_runners/
+               OUTPUT_NAME test_${test_name})
 
 endmacro(add_unit_test_executable)
 
 add_subdirectory(commons)
 add_subdirectory(candlelib)
 if(PYTHON_BUILD)
-    add_subdirectory(pycandle)
+  add_subdirectory(pycandle)
 else()
-    add_subdirectory(candletool)
-    add_subdirectory(examples)
+  add_subdirectory(candletool)
+  add_subdirectory(examples)
 endif()

--- a/candlelib/src/communication_interface/USB.cpp
+++ b/candlelib/src/communication_interface/USB.cpp
@@ -1,6 +1,19 @@
 #include <USB.hpp>
 #include <cstring>
 #include <string>
+#ifdef WIN32
+#define NO_DRIVER_EXTENDED_HELPER_MESSAGE                                    \
+    "No such device (it may have been disconnected). "                       \
+    "If you are on Windows please make sure you have installed the driver. " \
+    "You can do it by running \"candletool candle driver\" command. "
+#define NOT_SUPPORTED_EXTENDED_HELPER_MESSAGE                                \
+    "Windows kernel related issue occurred. "                                \
+    "If you are on Windows please make sure you have installed the driver. " \
+    "You can do it by running \"candletool candle driver\" command. "
+#else
+#define NO_DRIVER_EXTENDED_HELPER_MESSAGE     "No such device (it may have been disconnected)"
+#define NOT_SUPPORTED_EXTENDED_HELPER_MESSAGE "Windows kernel related issue occurred."
+#endif
 
 namespace mab
 {
@@ -21,7 +34,7 @@ namespace mab
             case LIBUSB_ERROR_IO:
                 return "Success (no error)";
             case LIBUSB_ERROR_NO_DEVICE:
-                return "No such device (it may have been disconnected)";
+                return NO_DRIVER_EXTENDED_HELPER_MESSAGE;
             case LIBUSB_ERROR_NO_MEM:
                 return "Insufficient memory.";
             case LIBUSB_ERROR_NOT_FOUND:
@@ -33,7 +46,7 @@ namespace mab
             case LIBUSB_ERROR_PIPE:
                 return "Control request not supported by the device";
             case LIBUSB_ERROR_NOT_SUPPORTED:
-                return "Windows kernel related issue ocurred";
+                return NOT_SUPPORTED_EXTENDED_HELPER_MESSAGE;
             case LIBUSB_ERROR_TIMEOUT:
                 return "Timed out";
             default:

--- a/candletool/CMakeLists.txt
+++ b/candletool/CMakeLists.txt
@@ -9,93 +9,100 @@ set(CANDLETOOL_VERSION_MINOR ${CANDLESDK_VERSION_2})
 set(CANDLETOOL_VERSION_PATCH ${CANDLESDK_VERSION_3})
 set(CANDLETOOL_VERSION_TAG "r")
 
-set(CANDLETOOL_VERSION_FULL "${CANDLETOOL_VERSION_MAJOR}.${CANDLETOOL_VERSION_MINOR}.${CANDLETOOL_VERSION_PATCH}-${CANDLETOOL_VERSION_TAG}")
+set(CANDLETOOL_VERSION_FULL
+    "${CANDLETOOL_VERSION_MAJOR}.${CANDLETOOL_VERSION_MINOR}.${CANDLETOOL_VERSION_PATCH}-${CANDLETOOL_VERSION_TAG}"
+)
 
 add_subdirectory(3rd_party/CLI11)
 
 set(CANDLETOOL_SOURCES
-
-  src/candle_cli.cpp
-  src/canLoader.cpp
-  src/md_cli.cpp
-  src/mab_crc.cpp
-  src/mabFileParser.cpp
-  src/main.cpp
-  src/pds_cli.cpp
-  src/utilities.cpp
-
-)
+    src/candle_cli.cpp
+    src/canLoader.cpp
+    src/md_cli.cpp
+    src/mab_crc.cpp
+    src/mabFileParser.cpp
+    src/main.cpp
+    src/pds_cli.cpp
+    src/utilities.cpp)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 
 add_executable(candletool ${CANDLETOOL_SOURCES})
 
 target_link_libraries(candletool candle logger)
 
-target_include_directories(candletool PUBLIC
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rd_party/mINI/src
-
-)
+target_include_directories(
+  candletool PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+                    ${CMAKE_CURRENT_SOURCE_DIR}/3rd_party/mINI/src)
 
 target_compile_options(candletool PRIVATE -g)
 
 set_target_properties(candletool PROPERTIES OUTPUT_NAME "candletool")
 
-target_compile_definitions(candletool PRIVATE
-    CANDLETOOL_VMAJOR=${CANDLETOOL_VERSION_MAJOR}
-    CANDLETOOL_VMINOR=${CANDLETOOL_VERSION_MINOR}
-    CANDLETOOL_VREVISION=${CANDLETOOL_VERSION_PATCH}
-    CANDLETOOL_VTAG=${CANDLETOOL_VERSION_TAG}
-)
+target_compile_definitions(
+  candletool
+  PRIVATE CANDLETOOL_VMAJOR=${CANDLETOOL_VERSION_MAJOR}
+          CANDLETOOL_VMINOR=${CANDLETOOL_VERSION_MINOR}
+          CANDLETOOL_VREVISION=${CANDLETOOL_VERSION_PATCH}
+          CANDLETOOL_VTAG=${CANDLETOOL_VERSION_TAG})
 
 target_link_libraries(candletool CLI11)
 
 # add_unit_test_executable(pds_cli_test tests/pds_cli_test.cpp)
 # target_include_directories(pds_cli_test PRIVATE include)
-# target_link_libraries(pds_cli_test PRIVATE CLI11 shared_data)
-# target_
+# target_link_libraries(pds_cli_test PRIVATE CLI11 shared_data) target_
 
-add_custom_command(TARGET candletool
+add_custom_command(
+  TARGET candletool
   POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/ ${CMAKE_CURRENT_BINARY_DIR}/
-  COMMENT "Copying configs..."
-  )
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/
+    ${CMAKE_CURRENT_BINARY_DIR}/
+  COMMENT "Copying configs...")
 
 # package / installer
 set(CPACK_PROJECT_NAME "candletool")
 set(CPACK_PACKAGE_NAME candletool)
-set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CANDLETOOL_VERSION_FULL}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR})
+set(CPACK_PACKAGE_FILE_NAME
+    ${CPACK_PACKAGE_NAME}-${CANDLETOOL_VERSION_FULL}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+)
 set(CPACK_PACKAGE_VERSION_MAJOR ${CANDLETOOL_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${CANDLETOOL_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${CANDLETOOL_VERSION_PATCH})
 set(CPACK_PACKAGE_VENDOR "MAB Robotics")
-set(CPACK_PACKAGE_DESCRIPTION "Console tool for MAB devices ecosystem configuration")
+set(CPACK_PACKAGE_DESCRIPTION
+    "Console tool for MAB devices ecosystem configuration")
 set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE)
 set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
 set(CPACK_MONOLITHIC_INSTALL ON)
 
-
 if(WIN32)
-    install(TARGETS candletool
-            RUNTIME
-            COMPONENT candletool)
+  add_executable(candle-win-driver IMPORTED
+                 ${CMAKE_CURRENT_SOURCE_DIR}/tools/candlesdk-win-driver.exe)
 
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/config/motors
-          DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/candletool/config"
-          COMPONENT _configs)
+  install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/tools/candlesdk-win-driver.exe
+          TYPE BIN)
+  install(TARGETS candletool RUNTIME COMPONENT candletool)
 
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/config/candletool.ini
-          DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/candletool/config"
-          PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ WORLD_WRITE
-          COMPONENT _configs)
-    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
-    set(CPACK_NSIS_MODIFY_PATH ON)
-    set(CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}/MAB.ico")
-    set(CPACK_NSIS_MUI_UNIICON "${CMAKE_CURRENT_SOURCE_DIR}/MAB.ico")
-    target_link_libraries(
+  install(
+    DIRECTORY
+      ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/config/motors
+    DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/candletool/config"
+    COMPONENT _configs)
+
+  install(
+    FILES
+      ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/config/candletool.ini
+    DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/candletool/config"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
+                WORLD_WRITE
+    COMPONENT _configs)
+  set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+  set(CPACK_NSIS_MODIFY_PATH ON)
+  set(CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}/MAB.ico")
+  set(CPACK_NSIS_MUI_UNIICON "${CMAKE_CURRENT_SOURCE_DIR}/MAB.ico")
+  target_link_libraries(
     candletool
     -static
     candle
@@ -106,45 +113,54 @@ if(WIN32)
 
 elseif(UNIX)
 
-    install(TARGETS candletool
-          RUNTIME
-          COMPONENT candletool)
+  install(TARGETS candletool RUNTIME COMPONENT candletool)
 
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/config/motors
-          DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/candletool/config"
-          COMPONENT _configs)
+  install(
+    DIRECTORY
+      ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/config/motors
+    DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/candletool/config"
+    COMPONENT _configs)
 
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/config/candletool.ini
-          DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/candletool/config"
-          PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ WORLD_WRITE
-          COMPONENT _configs)
+  install(
+    FILES
+      ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/candletool/config/candletool.ini
+    DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/candletool/config"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
+                WORLD_WRITE
+    COMPONENT _configs)
 
-    set(CPACK_GENERATOR "DEB")
-    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "MAB Robotics <contact@mabrobotics.pl>")
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS libusb-1.0-0)
-    set(CPACK_DEBIAN_PACKAGE_VERSION)
+  set(CPACK_GENERATOR "DEB")
+  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "MAB Robotics <contact@mabrobotics.pl>")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS libusb-1.0-0)
+  set(CPACK_DEBIAN_PACKAGE_VERSION)
 
-    if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+  if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
 
-        set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "arm64")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "arm64")
 
-    elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armhf")
+  elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armhf")
 
-        set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "armhf")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "armhf")
 
-    endif()
-    message(CPACK_DEBIAN_PACKAGE_ARCHITECTURE = ${CPACK_DEBIAN_PACKAGE_ARCHITECTURE})
+  endif()
+  message(CPACK_DEBIAN_PACKAGE_ARCHITECTURE =
+          ${CPACK_DEBIAN_PACKAGE_ARCHITECTURE})
 
-    set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/template_package/postinst")
+  set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
+      "${CMAKE_CURRENT_SOURCE_DIR}/template_package/postinst")
 
+  install(
+    FILES
+      ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/udev/rules.d/99-candletool.rules
+    DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/udev/rules.d/")
 
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/template_package/etc/udev/rules.d/99-candletool.rules
-          DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/udev/rules.d/")
-
-    install(FILES "${PROJECT_SOURCE_DIR}/template_package/etc/candletool/config/candletool.ini"
-          DESTINATION "/etc/candletool/"
-          PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
-          WORLD_WRITE EXCLUDE_FROM_ALL)
+  install(
+    FILES
+      "${PROJECT_SOURCE_DIR}/template_package/etc/candletool/config/candletool.ini"
+    DESTINATION "/etc/candletool/"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
+                WORLD_WRITE
+    EXCLUDE_FROM_ALL)
 
 endif()
 


### PR DESCRIPTION
Changes:
- Added static libwdi program for swapping drivers
- Added candletool command `candletool candle driver` to run program with administrator privileges 
- Made `windows.h` *lean and mean* to improve compile times. More info [here](https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers#faster-builds-with-smaller-header-files).
- Added printed info on errors when driver is not installed