### PR TITLE
Change submodule URLs to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "commons/googletest"]
 	path = commons/googletest
-	url = git@github.com:google/googletest.git
+	url = https://github.com/google/googletest.git
 [submodule "pycandle/3rd_party/pybind11"]
 	path = pycandle/3rd_party/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git
 [submodule "candletool/3rd_party/CLI11"]
 	path = candletool/3rd_party/CLI11
 	url = https://github.com/CLIUtils/CLI11.git


### PR DESCRIPTION
Updated submodule URLs to use HTTPS instead of SSH.

So this repo can be cloned recursively without having Github SSH keys configured