### PR TITLE
CS-242-bugfixes

### DIFF
--- a/candlelib/src/MD/MD_strings.hpp
+++ b/candlelib/src/MD/MD_strings.hpp
@@ -114,6 +114,35 @@ namespace mab
             return std::nullopt;
         }
     };
+    struct MDMainEncoderCalibrationModeValue_S
+    {
+        static inline const std::map<u32, std::string_view> fromNumericMap{{0, "FULL"},
+                                                                           {1, "NOPPDET"}};
+        static inline const std::map<std::string_view, u32> toNumericMap{{"FULL", 0},
+                                                                         {"NOPPDET", 1}};
+
+        static std::optional<u32> toNumeric(const std::string_view val)
+        {
+            if (std::isdigit(val[0]))
+                return std::stoi(val.data());
+            auto it = toNumericMap.find(val);
+            if (it != toNumericMap.end())
+            {
+                return it->second;
+            }
+            return std::nullopt;
+        }
+
+        static std::optional<std::string> toReadable(u32 val)
+        {
+            auto it = fromNumericMap.find(val);
+            if (it != fromNumericMap.end())
+            {
+                return std::string(it->second);
+            }
+            return std::nullopt;
+        }
+    };
     struct MDAuxEncoderCalibrationModeValue_S
     {
         static inline const std::map<u32, std::string_view> fromNumericMap{{0, "FULL"},

--- a/candletool/include/md_cfg_map.hpp
+++ b/candletool/include/md_cfg_map.hpp
@@ -102,7 +102,11 @@ namespace mab
             {0x015, MDCfgElement("motor", "torque constant c")},
             {0x019, MDCfgElement("motor", "dynamic friction")},
             {0x01A, MDCfgElement("motor", "static friction")},
-            {0x01E, MDCfgElement("motor", "calibration mode")},
+            {0x01E,
+             MDCfgElement("motor",
+                          "calibration mode",
+                          mainEncoderCalibrationModeToReadable,
+                          mainEncoderCalibrationModeFromReadable)},
             {0x808, MDCfgElement("motor", "shutdown temp")},
             {0x600, MDCfgElement("motor", "reverse direction")},
 
@@ -116,7 +120,11 @@ namespace mab
                           "output encoder mode",
                           encoderModeToReadable,
                           encoderModeFromReadable)},
-            {0x026, MDCfgElement("output encoder", "output encoder calibration mode")},
+            {0x026,
+             MDCfgElement("output encoder",
+                          "output encoder calibration mode",
+                          auxEncoderCalibrationModeToReadable,
+                          auxEncoderCalibrationModeFromReadable)},
 
             // PID parameters
             {0x030, MDCfgElement("position PID", "kp")},
@@ -180,6 +188,16 @@ namespace mab
         static const std::function<std::optional<std::string>(const std::string_view)>
             encoderFromReadable;
 
+        static const std::function<std::string(std::string_view)>
+            mainEncoderCalibrationModeToReadable;
+        static const std::function<std::optional<std::string>(const std::string_view)>
+            mainEncoderCalibrationModeFromReadable;
+
+        static const std::function<std::string(std::string_view)>
+            auxEncoderCalibrationModeToReadable;
+        static const std::function<std::optional<std::string>(const std::string_view)>
+            auxEncoderCalibrationModeFromReadable;
+
         static const std::function<std::string(std::string_view)> encoderModeToReadable;
         static const std::function<std::optional<std::string>(const std::string_view)>
             encoderModeFromReadable;
@@ -208,11 +226,52 @@ namespace mab
         return MDAuxEncoderValue_S::toReadable(std::stoll(value.data())).value_or("NOT FOUND");
     };
 
-    // Special case for encoder mode
+    // Special case for main encoder calibration mode
+
+    inline const std::function<std::string(std::string_view)>
+        MDConfigMap::mainEncoderCalibrationModeToReadable =
+            [](const std::string_view value) -> std::string
+    {
+        std::string output = trim(value);
+        return MDMainEncoderCalibrationModeValue_S::toReadable(std::stoll(output))
+            .value_or("NOT FOUND");
+    };
+
+    inline const std::function<std::optional<std::string>(const std::string_view)>
+        MDConfigMap::mainEncoderCalibrationModeFromReadable =
+            [](const std::string_view value) -> std::optional<std::string>
+    {
+        std::string output = trim(value);
+        return std::to_string(
+            MDMainEncoderCalibrationModeValue_S::toNumeric(value.data()).value_or(0));
+    };
+
+    // Special case for aux encoder calibration mode
+
+    inline const std::function<std::string(std::string_view)>
+        MDConfigMap::auxEncoderCalibrationModeToReadable =
+            [](const std::string_view value) -> std::string
+    {
+        std::string output = trim(value);
+        return MDAuxEncoderCalibrationModeValue_S::toReadable(std::stoll(output))
+            .value_or("NOT FOUND");
+    };
+
+    inline const std::function<std::optional<std::string>(const std::string_view)>
+        MDConfigMap::auxEncoderCalibrationModeFromReadable =
+            [](const std::string_view value) -> std::optional<std::string>
+    {
+        std::string output = trim(value);
+        return std::to_string(
+            MDAuxEncoderCalibrationModeValue_S::toNumeric(value.data()).value_or(0));
+    };
+
+    // Special case for aux encoder mode
     inline const std::function<std::string(std::string_view)> MDConfigMap::encoderModeToReadable =
         [](const std::string_view value) -> std::string
     {
         std::string output = trim(value);
+        std::cout << "ENCODER MODE RAW: '" << output << "'" << std::endl;
         return MDAuxEncoderModeValue_S::toReadable(std::stoll(output)).value_or("NOT FOUND");
     };
 

--- a/candletool/src/md_cli.cpp
+++ b/candletool/src/md_cli.cpp
@@ -675,6 +675,16 @@ namespace mab
                         auto fault = md->readRegisters(reg);
                         if (fault != MD::Error_t::OK)
                             m_logger.error("Error while reading register %s", reg.m_name.data());
+
+                        if constexpr (std::is_integral_v<decltype(reg.value)>)
+                        {
+                            m_logger.debug(
+                                "Read register %s, Value: %d", reg.m_name.data(), reg.value);
+                        }
+                        else
+                        {
+                            m_logger.debug("Read register %s", reg.m_name.data());
+                        }
                     }
                 };
 
@@ -722,8 +732,8 @@ namespace mab
                          << std::to_string(readableRegisters.motorShutdownTemp.value) << " *C"
                          << std::endl;
                 m_logger << "- motor calibration mode: "
-                         << MDAuxEncoderCalibrationModeValue_S::toReadable(
-                                readableRegisters.auxEncoderCalibrationMode.value)
+                         << MDMainEncoderCalibrationModeValue_S::toReadable(
+                                readableRegisters.motorCalibrationMode.value)
                                 .value_or("Unknown")
                          << std::endl;
                 m_logger << "- motor torque constant: " << std::setprecision(4)
@@ -1102,8 +1112,7 @@ namespace mab
                     {
                         m_logger.error(
                             "Please provide version of fw or  \"latest\" keyword in the argument!");
-                        m_logger.error(
-                            "For example candletool md update latest");
+                        m_logger.error("For example candletool md update latest");
                         return;
                     }
                     std::string fallbackPath = ctx.packageEtcPath->generic_string();


### PR DESCRIPTION
Fixes:
- Motor calibration mode now accepts noppdet and displays it properly in info and config commands