### PR TITLE
Pds 7 pds ping on multiple baudrates

### DIFF
--- a/candlelib/src/pds/pds.hpp
+++ b/candlelib/src/pds/pds.hpp
@@ -15,6 +15,11 @@
 
 namespace mab
 {
+    struct canIdAndRate
+    {
+        canId_t          id;
+        CANdleDatarate_E datarate;
+    };
 
     /**
      * @brief Power distribution system class
@@ -102,7 +107,7 @@ namespace mab
 
         static const char* moduleTypeToString(moduleType_E type);
 
-        static const std::vector<canId_t> discoverPDS(Candle* candle);
+        static const std::vector<canIdAndRate> discoverPDS(mab::candleTypes::busTypes_t busType);
 
       private:
         /**

--- a/candletool/src/pds_cli.cpp
+++ b/candletool/src/pds_cli.cpp
@@ -373,17 +373,18 @@ void PdsCli::parse()
 
         else if (m_discovery->parsed())
         {
-            auto candle = m_candleBuilder->build();
-            if (!candle.has_value())
+            auto pdsIdAndRates = Pds::discoverPDS(*m_candleBuilder->busType);
+            if (pdsIdAndRates.empty())
             {
-                m_log.error("Could not connect candle!");
+                m_log.error("No PDS found");
             }
-            auto ids = Pds::discoverPDS(candle.value());
-            if (ids.empty())
-                m_log.error("No PDS found on this datarate!");
-            for (const auto& id : ids)
+            else
             {
-                m_log.success("Found PDS with ID %d", id);
+                m_log.success("Found PDS: ");
+                for (const auto& pdsData : pdsIdAndRates)
+                {
+                    m_log.info("ID: %d, datarate: %dM", pdsData.id, pdsData.datarate);
+                }
             }
         }
 

--- a/examples/cpp/app_template.cpp
+++ b/examples/cpp/app_template.cpp
@@ -18,11 +18,11 @@ int main(int argc, char** argv)
     auto candle = std::unique_ptr<mab::Candle>(
         attachCandle(mab::CANdleDatarate_E::CAN_DATARATE_1M, mab::candleTypes::busTypes_t::USB));
 
-    for (const auto& id : mab::Pds::discoverPDS(candle.get()))
+    for (const auto& canIdAndRate : mab::Pds::discoverPDS(mab::candleTypes::busTypes_t::USB))
     {
-        log.info("Found PDS with CAN ID: %u", id);
-        pdsV.emplace_back(id, candle.get());
-        pdsV.back().init(id);
+        log.info("Found PDS with CAN ID: %u", canIdAndRate.id);
+        pdsV.emplace_back(canIdAndRate.id, candle.get());
+        pdsV.back().init(canIdAndRate.id);
     }
 
     for (const auto& id : mab::MD::discoverMDs(candle.get()))

--- a/examples/cpp/pds_example_braking_resistor.cpp
+++ b/examples/cpp/pds_example_braking_resistor.cpp
@@ -51,5 +51,7 @@ int main()
     _log.info("Temperature :: [ %.2f °C ]", temperature);
     _log.info("Temperature limit :: [ %.2f °C ]", temperatureLimit);
 
+    detachCandle(candle);
+
     return EXIT_SUCCESS;
 }

--- a/examples/cpp/pds_example_isolated_converter.cpp
+++ b/examples/cpp/pds_example_isolated_converter.cpp
@@ -20,8 +20,8 @@ int main()
     Logger _log;
     _log.m_tag = "PDS Example";
 
-    auto candle =
-        mab::attachCandle(mab::CANdleDatarate_E::CAN_DATARATE_1M, mab::candleTypes::busTypes_t::USB);
+    auto candle = mab::attachCandle(mab::CANdleDatarate_E::CAN_DATARATE_1M,
+                                    mab::candleTypes::busTypes_t::USB);
 
     Pds pds(PDS_CAN_ID, candle);
 
@@ -73,6 +73,8 @@ int main()
     _log.info("Temperature limit :: [ %.2f °C ]", temperatureLimit);
 
     isolatedConverter->disable();
+
+    detachCandle(candle);
 
     return EXIT_SUCCESS;
 }

--- a/examples/cpp/pds_example_ping_and_status.cpp
+++ b/examples/cpp/pds_example_ping_and_status.cpp
@@ -129,5 +129,7 @@ int main()
     m_log.info("Metrology data:");
     m_log.info("Bus voltage: %0.2f V", pdsBusVoltage / 1000.0f);
 
+    detachCandle(candle);
+
     return EXIT_SUCCESS;
 }

--- a/examples/cpp/pds_example_ping_and_status.cpp
+++ b/examples/cpp/pds_example_ping_and_status.cpp
@@ -21,7 +21,7 @@ int main()
     m_log.m_layer = Logger::ProgramLayer_E::TOP;
 
     auto candle    = attachCandle(CANdleDatarate_E::CAN_DATARATE_1M, candleTypes::busTypes_t::USB);
-    auto findPdses = Pds::discoverPDS(candle);
+    auto findPdses = Pds::discoverPDS(candleTypes::busTypes_t::USB);
 
     if (findPdses.size() == 0)
     {
@@ -29,7 +29,7 @@ int main()
         return EXIT_FAILURE;
     }
 
-    Pds pds(findPdses[0], candle);
+    Pds pds(findPdses[0].id, candle);
 
     pds.init();
 

--- a/examples/cpp/pds_example_power_stage.cpp
+++ b/examples/cpp/pds_example_power_stage.cpp
@@ -72,5 +72,7 @@ int main()
 
     powerStage->disable();
 
+    detachCandle(candle);
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Now PDS discover method checks all available IDs on all baudrates. findpds now uses only type of BUS (USB or SPI).
Added candle detachment to PDS examples.